### PR TITLE
Convert enum to string

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -29,6 +29,7 @@ abstract class Enum
      * PROTECTED!! Not callable directly.
      * @see static::instance()
      * @see static::__callStatic()
+     * @internal
      *
      * @param string $value
      */
@@ -43,6 +44,13 @@ abstract class Enum
         $this->value = $value;
     }
 
+    /**
+     *
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
 
     /**
      * @param string $method
@@ -54,7 +62,6 @@ abstract class Enum
     {
         return static::instance($method);
     }
-
 
     /**
      * @param string $value

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -69,4 +69,13 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $open = TestEnum::OPEN();
         $this->assertSame($open, TestEnum::OPEN());
     }
+
+	/**
+	 * @test
+	 */
+    public function stringRepresentation()
+    {
+	    $open = TestEnum::OPEN();
+	    $this->assertEquals('OPEN', (string) TestEnum::OPEN());
+    }
 }


### PR DESCRIPTION
Implementation  __toString() method which converts Enum to representation in string